### PR TITLE
Added requirements for Sphinx build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,8 @@ build:
     python: "3.10"
   
 sphinx:
+  builder: html
+  configuration: docs/source/conf.py
   fail_on_warning: true
 
 python:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,7 @@ sphinx:
 
 python:
   install:
+    - requirements: docs/requirements.txt
     - method: pip
       path: .
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+docutils==0.16
+sphinx==4.4.0
+sphinx_rtd_theme==0.4.3


### PR DESCRIPTION
docs/requirements.txt contains the pinned versions of Sphinx, Sphinx rtd theme and docutils
to use when building the docs. Update .readthedocs.yaml to use this requirements file.